### PR TITLE
all: rename `onChange` to `onChanged`

### DIFF
--- a/example/lib/pages/components/input.dart
+++ b/example/lib/pages/components/input.dart
@@ -136,8 +136,8 @@ class _InputPageState extends State<InputPage> {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Checkbox(
-                        checked: _checkboxValue,
-                        onChange: (value) {
+                        value: _checkboxValue,
+                        onChanged: (value) {
                           setState(() {
                             _checkboxValue = value;
                           });

--- a/lib/src/components/buttons/tab_button.dart
+++ b/lib/src/components/buttons/tab_button.dart
@@ -13,7 +13,7 @@ class TabButton extends StatefulWidget {
   final ButtonState? state;
 
   /// Optional callback to be called when the button is pressed.
-  final ValueChanged<bool>? onChange;
+  final ValueChanged<bool>? onChanged;
 
   /// The child widget to render.
   final Widget child;
@@ -23,7 +23,7 @@ class TabButton extends StatefulWidget {
     required this.selected,
     required this.child,
     this.state,
-    this.onChange,
+    this.onChanged,
   });
 
   @override
@@ -91,7 +91,7 @@ class _TabButtonState extends State<TabButton> {
                   onTapDown: handleTapDown,
                   onTapUp: handleTapUp,
                   onTapCancel: handleTapUp,
-                  onTap: () => widget.onChange?.call(!widget.selected),
+                  onTap: () => widget.onChanged?.call(!widget.selected),
                   child: AnimatedContainer(
                     padding: EdgeInsets.symmetric(
                       vertical: context.theme.spacing.xs,

--- a/lib/src/components/buttons/toggle_button.dart
+++ b/lib/src/components/buttons/toggle_button.dart
@@ -16,7 +16,7 @@ class ToggleButton extends StatefulWidget {
   final ButtonState? state;
 
   /// Optional callback to be called when the button is pressed.
-  final ValueChanged<bool>? onChange;
+  final ValueChanged<bool>? onChanged;
 
   /// The child widget to render.
   final Widget child;
@@ -27,7 +27,7 @@ class ToggleButton extends StatefulWidget {
     required this.selected,
     required this.child,
     this.state,
-    this.onChange,
+    this.onChanged,
   });
 
   @override
@@ -95,7 +95,7 @@ class _ToggleButtonState extends State<ToggleButton> {
                   onTapDown: handleTapDown,
                   onTapUp: handleTapUp,
                   onTapCancel: handleTapUp,
-                  onTap: () => widget.onChange?.call(!widget.selected),
+                  onTap: () => widget.onChanged?.call(!widget.selected),
                   child: AnimatedContainer(
                     width: 40.0,
                     height: 40.0,

--- a/lib/src/components/input/checkbox.dart
+++ b/lib/src/components/input/checkbox.dart
@@ -29,16 +29,16 @@ enum CheckboxState {
 class Checkbox extends StatefulWidget {
   const Checkbox({
     Key? key,
-    required this.checked,
-    required this.onChange,
+    required this.value,
+    required this.onChanged,
     this.state,
   }) : super(key: key);
 
   /// Checked state of the checkbox.
-  final bool checked;
+  final bool value;
 
   /// Called when the checkbox is tapped.
-  final ValueChanged<bool> onChange;
+  final ValueChanged<bool> onChanged;
 
   /// Override default initial state.
   final CheckboxState? state;
@@ -117,7 +117,7 @@ class _CheckboxState extends State<Checkbox> {
           onTapDown: handleTapDown,
           onTapUp: handleTapUp,
           onTapCancel: handleTapUp,
-          onTap: () => widget.onChange.call(!widget.checked),
+          onTap: () => widget.onChanged.call(!widget.value),
           child: AnimatedContainer(
             duration: context.theme.motion.short,
             width: 24,
@@ -126,7 +126,7 @@ class _CheckboxState extends State<Checkbox> {
               context.theme.spacing.xxxs,
             ),
             decoration: BoxDecoration(
-              color: widget.checked ? context.theme.colors.primary : null,
+              color: widget.value ? context.theme.colors.primary : null,
               borderRadius: BorderRadius.circular(
                 context.theme.shapes.sm,
               ),
@@ -135,7 +135,7 @@ class _CheckboxState extends State<Checkbox> {
                 width: 1,
               ),
             ),
-            child: widget.checked
+            child: widget.value
                 ? Center(
                     child: Icon(
                       Icons.check,
@@ -151,7 +151,7 @@ class _CheckboxState extends State<Checkbox> {
   }
 
   Color getBorderColor() {
-    if (widget.checked) {
+    if (widget.value) {
       switch (state) {
         case CheckboxState.normal:
           return context.theme.colors.overlay30;

--- a/lib/src/components/input/checkbox.dart
+++ b/lib/src/components/input/checkbox.dart
@@ -139,7 +139,7 @@ class _CheckboxState extends State<Checkbox> {
                 ? Center(
                     child: Icon(
                       Icons.check,
-                      size: 12,
+                      size: 16,
                       color: context.theme.colors.onPrimary,
                     ),
                   )


### PR DESCRIPTION
This will align the API with the familiar Material API. Also renames `checked` to `value` for the same reason.